### PR TITLE
quoting of values containing colons ':'

### DIFF
--- a/lib/Data/YAML/Writer.pm
+++ b/lib/Data/YAML/Writer.pm
@@ -76,7 +76,7 @@ sub _enc_scalar {
 
   return '~' unless defined $val;
 
-  if ( $val =~ /$ESCAPE_CHAR/ ) {
+  if ( $val =~ /$ESCAPE_CHAR/ or $val =~ /:$/ ) {
     $val =~ s/\\/\\\\/g;
     $val =~ s/"/\\"/g;
     $val =~ s/ ( [\x00-\x1f] ) / '\\' . $UNPRINTABLE[ ord($1) ] /gex;

--- a/t/40-writer.t
+++ b/t/40-writer.t
@@ -80,6 +80,38 @@ BEGIN {
       out  => [ '---', "'': ''", '...', ],
     },
     {
+      name => 'Single colon value',
+      in   => { 'zomtec' => { 'colon' => ':' } },
+      out  => [ '---',
+                "zomtec:",
+                '  colon: ":"',
+                '...', ],
+    },
+    {
+      name => 'Colon at beginning of value',
+      in   => { 'zomtec' => { 'colons' => ':zomtec' } },
+      out  => [ '---',
+                "zomtec:",
+                '  colons: :zomtec',
+                '...', ],
+    },
+    {
+      name => 'Colon in the middle of value',
+      in   => { 'zomtec' => { 'colons' => 'affe:zomtec' } },
+      out  => [ '---',
+                "zomtec:",
+                '  colons: affe:zomtec',
+                '...', ],
+    },
+    {
+      name => 'Colon at end of value',
+      in   => { 'zomtec' => { 'colons' => 'zomtec:' } },
+      out  => [ '---',
+                "zomtec:",
+                '  colons: "zomtec:"',
+                '...', ],
+    },
+    {
       name => 'Complex',
       in   => {
         'bill-to' => {


### PR DESCRIPTION
A ':' as last or single character of a value
confuses YAML readers. The most consistent
behaviour among all YAML parsers (i.e, YAML,
YAML::XS, Data::YAML::Reader) is when we
quote all values that end with ':'.

We could quote generally everything that contains
a quote but hereby we only fix the minimum issue
which definitely did not work so far, so we don't
risk introducing backwards incompatibilities.